### PR TITLE
feat: Ink TUI — split-pane terminal interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,16 @@ Mastra AI agent project — Asklepios.
 ## Architecture
 
 ```
-{{Draw your architecture here. Example:}}
 src/
 ├── agents/       # Agent definitions and prompts
 ├── tools/        # Mastra tools (wrappers around external APIs / DB)
 ├── workflows/    # Multi-step orchestration workflows
-└── utils/        # Shared utilities (logger, validation)
+├── tui/          # Ink TUI components (React for terminal, .tsx files)
+├── mcp/          # MCP server (tools, resources, prompts, tasks)
+├── utils/        # Shared utilities (logger, validation)
+├── cli-core.ts   # Event-based streaming (shared by REPL + TUI)
+├── cli.ts        # REPL entry point (fallback)
+└── tui.tsx       # TUI entry point (default)
 ```
 
 ## Commands
@@ -118,3 +122,8 @@ Don't read these upfront — load them when relevant to your current task:
 - [2026-03-05] [Dynamic maxSteps] Hardcoded maxSteps insufficient: simple chat needs 5, research needs 15, deep diagnosis needs 20. Keyword-based heuristic with env var override (ASKLEPIOS_MAX_STEPS) balances efficiency and capability.
 - [2026-03-05] [MCP Tasks API] MCP SDK v1.27.1 experimental tasks: registerToolTask() does NOT accept inputSchema in config — it's inferred from generic type parameter. Handler methods: createTask/getTask/getTaskResult with RequestTaskStore.
 - [2026-03-05] [OMIM API] Requires free API key (omim.org registration). Entry prefix indicates type: `*` = gene, `#` = phenotype, `%` = cytogenetic region. Map to evidence levels for research findings.
+- [2026-03-05] [Ink 6.x] Requires React >=19.0.0 (not 18.x). Package exports only from main entry point (`ink`), not sub-paths (`ink/build/components/Box.js`). Import everything from `ink`.
+- [2026-03-05] [exactOptionalPropertyTypes] With strict TS, `agentId?: string` means the property is either missing OR a string — cannot assign `string | undefined`. Use conditional object spread or mutation to set optional fields.
+- [2026-03-05] [Ink TUI architecture] Event-based streaming (`cli-core.ts`) decouples business logic from rendering. Both REPL and TUI consume same `AsyncGenerator<StreamEvent>` — identical agent behavior, different UIs.
+- [2026-03-05] [Ink Static] Use `<Static items={[...]}>` for completed messages — prevents re-rendering when new text streams in. Critical for streaming performance in long conversations.
+- [2026-03-05] [Biome React] React components must be PascalCase but Biome enforces camelCase for functions. Add `.tsx` override in biome.json allowing `["camelCase", "PascalCase"]` for function names.

--- a/biome.json
+++ b/biome.json
@@ -94,12 +94,34 @@
     }
   },
   "files": {
-    "includes": ["src/**/*.ts", "tests/**/*.ts"],
+    "includes": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts"],
     "experimentalScannerIgnores": ["node_modules", "dist", "coverage", ".mastra"]
   },
   "overrides": [
     {
-      "includes": ["src/**/*.test.ts", "tests/**/*.ts"],
+      "includes": ["src/**/*.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNamingConvention": {
+              "level": "warn",
+              "options": {
+                "conventions": [
+                  { "selector": { "kind": "function" }, "formats": ["camelCase", "PascalCase"] },
+                  {
+                    "selector": { "kind": "variable" },
+                    "formats": ["camelCase", "CONSTANT_CASE", "PascalCase"]
+                  },
+                  { "selector": { "kind": "typeLike" }, "formats": ["PascalCase"] }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/**/*.test.ts", "src/**/*.test.tsx", "tests/**/*.ts"],
       "javascript": {
         "globals": ["jest"]
       },

--- a/docs/system-specs.md
+++ b/docs/system-specs.md
@@ -2,8 +2,8 @@
 
 > Rare Disease Research Agent with Diagnostic Odyssey Compression
 
-**Version:** 0.2.0
-**Status:** Core implementation complete + Phase 8 enhancements (ClinVar, rate limiting, dynamic maxSteps, MCP Tasks)
+**Version:** 0.3.0
+**Status:** Core implementation complete + Phase 8 enhancements + Ink TUI (split-pane terminal interface)
 
 ---
 
@@ -27,6 +27,7 @@ The killer feature is **Cross-Patient Observational Memory** — powered by Mast
 | LLM | Claude Sonnet 4 via @ai-sdk/anthropic | ^3.0.56 |
 | Embeddings | OpenAI text-embedding-3-small via @ai-sdk/openai | latest |
 | Validation | Zod | ^4.3.6 |
+| Terminal UI | Ink (React for CLI) + @inkjs/ui | ink ^6.8.0, react ^19.2.4 |
 | Linting | Biome v2 | ^2.4.4 |
 | Testing | Jest + ts-jest (ESM) | ^29.7.0 |
 
@@ -75,9 +76,19 @@ src/
 │   ├── ncbi-rate-limiter.ts   # Shared NCBI eUtils rate limiter with exponential backoff
 │   └── max-steps.ts           # Dynamic maxSteps resolution based on query complexity
 ├── memory.ts                  # Shared Memory + Storage instances
+├── tui/                       # Ink TUI components (split-pane terminal UI)
+│   ├── App.tsx                # Root component (session, keyboard shortcuts)
+│   ├── Header.tsx             # Status bar (patient, thread, mode, tokens)
+│   ├── ConversationPane.tsx   # Scrollable message list with streaming
+│   ├── MessageBubble.tsx      # Role-based message styling
+│   ├── InputBar.tsx           # TextInput with slash command support
+│   ├── useAsklepios.ts        # Hook encapsulating agent interaction logic
+│   └── types.ts               # Shared Message interface
 ├── mastra.ts                  # Mastra instance (agent/workflow registry)
-├── cli.ts                     # Interactive REPL entry point
+├── cli-core.ts                # Event-based streaming (shared by REPL + TUI)
+├── cli.ts                     # Interactive REPL entry point (fallback)
 ├── cli-utils.ts               # CLI session management & command parsing
+├── tui.tsx                    # TUI entry point (default)
 └── index.ts                   # Library export
 ```
 
@@ -221,16 +232,43 @@ Both workflows support **Human-in-the-Loop (HITL)** suspend/resume for critical 
 
 ---
 
-## CLI Interface
+## Terminal Interface
 
-Interactive REPL for direct agent interaction:
+Two UI modes share the same business logic via `cli-core.ts` event-based streaming:
+
+### TUI Mode (default) — Ink Split-Pane Layout
 
 ```bash
-npm start                        # Launch REPL
-npm start -- --patient marfan-42 # Launch with patient context
+npm start                        # Launch TUI (default)
+npm start -- --patient marfan-42 # Launch TUI with patient context
+npm run tui                      # Alias for npm start
 ```
 
-### Commands
+**Layout:**
+- **Header bar**: App title, patient context, thread ID (8 chars), network mode `[NET]/[DIRECT]`, live token counters
+- **Conversation pane**: Scrollable message list using Ink `<Static>` for completed messages (no re-renders), live streaming with `<Spinner>` while waiting for first token
+- **Input bar**: `<TextInput>` with slash command tab completion, disabled during streaming
+
+**Keyboard shortcuts:**
+- `Ctrl+N` — new thread
+- `Ctrl+T` — toggle network mode
+- `Ctrl+C` — exit
+
+**Components:** `App.tsx` (root) → `Header.tsx`, `ConversationPane.tsx` → `MessageBubble.tsx`, `InputBar.tsx`
+**State management:** `useAsklepios` hook encapsulates all agent interaction, consuming `StreamEvent` generators from `cli-core.ts`
+
+**Tech:** React 19 + Ink 6.8 + @inkjs/ui (TextInput, Spinner)
+
+### REPL Mode (fallback)
+
+```bash
+npm run start:repl                        # Launch readline REPL
+npm run start:repl -- --patient marfan-42 # REPL with patient context
+```
+
+Readline-based text interface for scripting, piping, and environments without full terminal support.
+
+### Commands (both modes)
 | Command | Action |
 |---------|--------|
 | `/help` | Show available commands |
@@ -242,6 +280,16 @@ npm start -- --patient marfan-42 # Launch with patient context
 | `/network` | Toggle network mode (multi-agent routing) |
 | `/resume <wf> <step> [json]` | Resume a suspended workflow with optional data |
 | `/quit` | Exit |
+
+### Event-Based Architecture
+
+`cli-core.ts` yields typed `StreamEvent` objects instead of writing directly to stdout:
+
+```
+StreamEvent = text | agent-label | usage | error | done
+```
+
+Both REPL (`cli.ts`) and TUI (`tui.tsx`) consume the same async generators, ensuring identical business logic regardless of rendering layer.
 
 ---
 
@@ -437,9 +485,9 @@ Intelligent step limit scaling via `resolveMaxSteps(message)` (`src/utils/max-st
 ## Testing
 
 ### Unit Tests
-- **315 tests** across 29 passing test suites
-- Colocated test files (`*.test.ts` next to source)
-- Coverage: tools (schema validation + execution), agents (config verification + network configuration + dynamic maxSteps), workflows (schema + structure + HITL suspend/resume schemas), processors (input/output behavior), CLI (command parsing + session management + network toggle), MCP server (registration tests for all 20 tools, 7 resources, 4 prompts + task-based tools), utils (model router, logger, usage tracker, observability, NCBI rate limiter, maxSteps resolver), ClinVar lookup (query building, schema validation)
+- **335 tests** across 32 passing test suites
+- Colocated test files (`*.test.ts` / `*.test.tsx` next to source)
+- Coverage: tools (schema validation + execution), agents (config verification + network configuration + dynamic maxSteps), workflows (schema + structure + HITL suspend/resume schemas), processors (input/output behavior), CLI (command parsing + session management + network toggle + cli-core event types), MCP server (registration tests for all 20 tools, 7 resources, 4 prompts + task-based tools), utils (model router, logger, usage tracker, observability, NCBI rate limiter, maxSteps resolver), ClinVar lookup (query building, schema validation), TUI components (Header rendering, MessageBubble role-based styling, token display)
 
 ### MCP Integration Tests
 - `scripts/test-mcp-integration.ts` — exercises MCP tools, resources, prompts via MCP SDK client

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 const config = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  extensionsToTreatAsEsm: ['.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
@@ -16,11 +16,11 @@ const config = {
     ],
   },
 
-  testMatch: ['**/src/**/*.test.ts', '**/tests/**/*.test.ts'],
+  testMatch: ['**/src/**/*.test.ts', '**/src/**/*.test.tsx', '**/tests/**/*.test.ts'],
   collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.test.ts',
-    '!src/**/*.spec.ts',
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.spec.{ts,tsx}',
     '!src/**/*.d.ts',
   ],
   coverageThreshold: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,24 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.56",
         "@ai-sdk/openai": "^3.0.41",
+        "@inkjs/ui": "^2.0.0",
         "@mastra/core": "^1.9.0",
         "@mastra/libsql": "^1.6.3",
         "@mastra/memory": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "ink": "^6.8.0",
+        "react": "^19.2.4",
         "zod": "^4.3.6"
       },
       "bin": {
+        "asklepios-tui": "dist/tui.js",
         "mastra-asklepios": "dist/cli.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@types/node": "^22.0.0",
+        "@types/react": "^19.2.14",
+        "ink-testing-library": "^4.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.3.0",
         "tsx": "^4.19.0",
@@ -210,6 +216,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1323,6 +1369,36 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@inkjs/ui": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inkjs/ui/-/ui-2.0.0.tgz",
+      "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-spinners": "^3.0.0",
+        "deepmerge": "^4.3.1",
+        "figures": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -2791,6 +2867,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -2978,6 +3064,18 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-jest": {
@@ -3377,6 +3475,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3401,6 +3597,18 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -3464,6 +3672,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -3533,6 +3750,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -3578,7 +3802,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3700,6 +3923,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -3739,6 +3974,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -4300,6 +4545,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4586,6 +4843,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4603,6 +4872,210 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -4672,6 +5145,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-network-error": {
@@ -5767,7 +6255,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5964,7 +6451,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -6103,6 +6589,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -6357,12 +6852,36 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6447,6 +6966,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -6497,6 +7032,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/section-matter": {
@@ -6685,7 +7226,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -6703,6 +7243,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -6736,7 +7319,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -6749,7 +7331,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6872,6 +7453,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -7251,6 +7856,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7393,6 +8056,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "mastra-asklepios": "dist/cli.js"
+    "mastra-asklepios": "dist/cli.js",
+    "asklepios-tui": "dist/tui.js"
   },
   "scripts": {
     "build": "tsc",
     "dev": "mastra dev",
-    "start": "node dist/cli.js",
+    "start": "node --env-file=.env dist/tui.js",
+    "start:repl": "node --env-file=.env dist/cli.js",
+    "tui": "node --env-file=.env dist/tui.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest --passWithNoTests --forceExit",
     "test:single": "node --experimental-vm-modules node_modules/.bin/jest --passWithNoTests",
     "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
@@ -30,15 +33,20 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.56",
     "@ai-sdk/openai": "^3.0.41",
+    "@inkjs/ui": "^2.0.0",
     "@mastra/core": "^1.9.0",
     "@mastra/libsql": "^1.6.3",
     "@mastra/memory": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "ink": "^6.8.0",
+    "react": "^19.2.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@types/node": "^22.0.0",
+    "@types/react": "^19.2.14",
+    "ink-testing-library": "^4.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.0",
     "tsx": "^4.19.0",

--- a/src/cli-core.test.ts
+++ b/src/cli-core.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+jest.mock('./mastra.js', () => ({
+  mastra: {
+    getAgent: jest.fn(),
+    getWorkflow: jest.fn(),
+  },
+}));
+
+jest.mock('./memory.js', () => ({
+  storage: {},
+  memory: {},
+  brainMemory: {},
+}));
+
+describe('cli-core', () => {
+  describe('StreamEvent type exports', () => {
+    it('exports streamDirect as async generator function', async () => {
+      const { streamDirect } = await import('./cli-core.js');
+      expect(typeof streamDirect).toBe('function');
+    });
+
+    it('exports streamNetwork as async generator function', async () => {
+      const { streamNetwork } = await import('./cli-core.js');
+      expect(typeof streamNetwork).toBe('function');
+    });
+
+    it('exports streamAgent as function', async () => {
+      const { streamAgent } = await import('./cli-core.js');
+      expect(typeof streamAgent).toBe('function');
+    });
+
+    it('exports handleResume as async function', async () => {
+      const { handleResume } = await import('./cli-core.js');
+      expect(typeof handleResume).toBe('function');
+    });
+  });
+
+  describe('handleResume', () => {
+    it('returns usage text when missing workflowId', async () => {
+      const { handleResume } = await import('./cli-core.js');
+      const result = await handleResume('/resume');
+      expect(result.success).toBe(false);
+      expect(result.output).toContain('Usage:');
+    });
+
+    it('returns usage text when missing stepId', async () => {
+      const { handleResume } = await import('./cli-core.js');
+      const result = await handleResume('/resume patient-intake');
+      expect(result.success).toBe(false);
+      expect(result.output).toContain('Usage:');
+    });
+
+    it('returns error for unknown workflow', async () => {
+      const { handleResume } = await import('./cli-core.js');
+      const result = await handleResume('/resume unknown-workflow step1');
+      expect(result.success).toBe(false);
+      expect(result.output).toContain('Unknown workflow');
+    });
+
+    it('returns error for invalid JSON resume data', async () => {
+      const { handleResume } = await import('./cli-core.js');
+      const result = await handleResume('/resume patient-intake review-phenotypes {bad json}');
+      expect(result.success).toBe(false);
+      expect(result.output).toContain('Invalid JSON');
+    });
+  });
+});

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -1,0 +1,210 @@
+/**
+ * Core streaming logic shared by both REPL (cli.ts) and TUI (tui.tsx).
+ *
+ * Exposes async generators that yield typed StreamEvents, decoupling
+ * business logic (agent calls, token tracking) from rendering.
+ */
+
+import type { Session } from './cli-utils.js';
+import { AGENT_ID, getPatientInstructions } from './cli-utils.js';
+import { mastra } from './mastra.js';
+import { resolveMaxSteps } from './utils/max-steps.js';
+import { traceOnFinish, traceOnStepFinish } from './utils/observability.js';
+import type { TokenUsage } from './utils/usage-tracker.js';
+
+// ─── Stream Event Types ──────────────────────────────────────────────────────
+
+export type StreamEvent =
+  | { type: 'text'; content: string }
+  | { type: 'agent-label'; agentId: string }
+  | { type: 'usage'; data: TokenUsage }
+  | { type: 'error'; message: string }
+  | { type: 'done' };
+
+// ─── Resume Result ───────────────────────────────────────────────────────────
+
+export interface ResumeResult {
+  success: boolean;
+  output: string;
+}
+
+// ─── Direct Streaming ────────────────────────────────────────────────────────
+
+export async function* streamDirect(
+  userMessage: string,
+  session: Session,
+): AsyncGenerator<StreamEvent> {
+  const agent = mastra.getAgent(AGENT_ID);
+  const patientInstructions = getPatientInstructions(session);
+  const runId = `run-${Date.now()}`;
+
+  const result = await agent.stream(userMessage, {
+    runId,
+    maxSteps: resolveMaxSteps(userMessage),
+    memory: {
+      thread: session.threadId,
+      resource: session.resourceId,
+    },
+    ...(patientInstructions ? { instructions: patientInstructions } : {}),
+    onFinish: traceOnFinish(runId),
+    onStepFinish: traceOnStepFinish(runId),
+  });
+
+  const reader = result.textStream.getReader();
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      yield { type: 'text', content: value };
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  try {
+    const usage = await result.usage;
+    yield { type: 'usage', data: usage };
+  } catch {
+    // Usage data unavailable — skip
+  }
+
+  yield { type: 'done' };
+}
+
+// ─── Network Chunk Parsing ──────────────────────────────────────────────────
+
+/** Parse a single network stream chunk into a StreamEvent, or null if irrelevant. */
+function parseNetworkChunk(
+  chunk: Record<string, unknown>,
+  currentAgentId: string,
+): { event: StreamEvent | null; agentId: string } {
+  const chunkType = chunk['type'] as string | undefined;
+  const payload = chunk['payload'] as Record<string, unknown> | undefined;
+
+  if (!(chunkType && payload)) return { event: null, agentId: currentAgentId };
+
+  if (chunkType === 'agent-execution-start') {
+    const agentId = (payload['agentId'] as string) ?? 'unknown';
+    if (agentId !== currentAgentId) {
+      return { event: { type: 'agent-label', agentId }, agentId };
+    }
+    return { event: null, agentId: currentAgentId };
+  }
+
+  if (!chunkType.startsWith('agent-execution-event-')) {
+    return { event: null, agentId: currentAgentId };
+  }
+
+  const innerType = (payload['type'] as string) ?? '';
+  if (innerType !== 'text-delta') return { event: null, agentId: currentAgentId };
+
+  const innerPayload = payload['payload'] as Record<string, unknown> | undefined;
+  const text = (innerPayload?.['text'] as string) ?? '';
+  if (text) {
+    return { event: { type: 'text', content: text }, agentId: currentAgentId };
+  }
+  return { event: null, agentId: currentAgentId };
+}
+
+// ─── Network Streaming ──────────────────────────────────────────────────────
+
+export async function* streamNetwork(
+  userMessage: string,
+  session: Session,
+): AsyncGenerator<StreamEvent> {
+  const agent = mastra.getAgent(AGENT_ID);
+  const patientInstructions = getPatientInstructions(session);
+
+  const networkStream = await agent.network(userMessage, {
+    memory: {
+      thread: session.threadId,
+      resource: session.resourceId,
+    },
+    ...(patientInstructions ? { instructions: patientInstructions } : {}),
+    maxSteps: resolveMaxSteps(userMessage),
+  });
+
+  const reader = networkStream.getReader();
+  let currentAgentId = '';
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const parsed = parseNetworkChunk(value as Record<string, unknown>, currentAgentId);
+      currentAgentId = parsed.agentId;
+      if (parsed.event) yield parsed.event;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  try {
+    const usage = await networkStream.usage;
+    yield { type: 'usage', data: usage };
+  } catch {
+    // Usage data unavailable — skip
+  }
+
+  yield { type: 'done' };
+}
+
+// ─── Unified Stream (dispatches based on session.networkMode) ────────────────
+
+export function streamAgent(userMessage: string, session: Session): AsyncGenerator<StreamEvent> {
+  if (session.networkMode) {
+    return streamNetwork(userMessage, session);
+  }
+  return streamDirect(userMessage, session);
+}
+
+// ─── Workflow Resume ─────────────────────────────────────────────────────────
+
+const VALID_WORKFLOWS = ['patient-intake', 'diagnostic-research'] as const;
+
+const RESUME_USAGE = [
+  'Usage: /resume <workflowId> <stepId> [resumeData as JSON]',
+  'Example: /resume patient-intake review-phenotypes \'{"approvedIndices":[0,1,2]}\'',
+  'Example: /resume diagnostic-research review-findings \'{"approvedFindingIndices":[0,1,2]}\'',
+  '',
+  'Available workflows: patient-intake, diagnostic-research',
+].join('\n');
+
+export async function handleResume(input: string): Promise<ResumeResult> {
+  const parts = input.split(/\s+/);
+  const workflowId = parts[1];
+  const stepId = parts[2];
+  const resumeDataRaw = parts.slice(3).join(' ');
+
+  if (!(workflowId && stepId)) {
+    return { success: false, output: RESUME_USAGE };
+  }
+
+  if (!VALID_WORKFLOWS.includes(workflowId as (typeof VALID_WORKFLOWS)[number])) {
+    return { success: false, output: `Unknown workflow: ${workflowId}` };
+  }
+
+  let resumeData: unknown = {};
+  if (resumeDataRaw) {
+    try {
+      resumeData = JSON.parse(resumeDataRaw);
+    } catch {
+      return { success: false, output: 'Invalid JSON in resume data' };
+    }
+  }
+
+  const workflow = mastra.getWorkflow(workflowId as 'patient-intake') as unknown as {
+    resume: (params: { step: string; resumeData: unknown }) => Promise<unknown>;
+  };
+
+  const result = await workflow.resume({
+    step: stepId,
+    resumeData,
+  });
+
+  return {
+    success: true,
+    output: `Resuming workflow "${workflowId}" at step "${stepId}"...\n\nWorkflow result: ${JSON.stringify(result, null, 2)}`,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,19 +1,10 @@
 #!/usr/bin/env node
 
 import * as readline from 'node:readline';
+import { handleResume, streamAgent } from './cli-core.js';
 import type { Session } from './cli-utils.js';
-import {
-  AGENT_ID,
-  createSession,
-  getPatientInstructions,
-  getPrompt,
-  handleCommand,
-  parseArgs,
-} from './cli-utils.js';
-import { mastra } from './mastra.js';
+import { createSession, getPrompt, handleCommand, parseArgs } from './cli-utils.js';
 import { logger } from './utils/logger.js';
-import { resolveMaxSteps } from './utils/max-steps.js';
-import { traceOnFinish, traceOnStepFinish } from './utils/observability.js';
 import {
   createSessionUsage,
   formatSessionUsage,
@@ -23,176 +14,35 @@ import {
 
 const sessionUsage = createSessionUsage();
 
-// ─── Workflow Resume ────────────────────────────────────────────────────────
+// ─── Streaming via cli-core event generators ────────────────────────────────
 
-async function handleResumeCommand(input: string): Promise<void> {
-  const parts = input.split(/\s+/);
-  const workflowId = parts[1];
-  const stepId = parts[2];
-  const resumeDataRaw = parts.slice(3).join(' ');
+async function writeStreamToStdout(message: string, session: Session): Promise<void> {
+  const stream = streamAgent(message, session);
 
-  if (!(workflowId && stepId)) {
-    process.stdout.write(
-      'Usage: /resume <workflowId> <stepId> [resumeData as JSON]\n' +
-        'Example: /resume patient-intake review-phenotypes \'{"approvedIndices":[0,1,2]}\'\n' +
-        'Example: /resume diagnostic-research review-findings \'{"approvedFindingIndices":[0,1,2]}\'\n' +
-        '\nAvailable workflows: patient-intake, diagnostic-research\n',
-    );
-    return;
-  }
-
-  let resumeData: unknown = {};
-  if (resumeDataRaw) {
-    try {
-      resumeData = JSON.parse(resumeDataRaw);
-    } catch {
-      process.stdout.write('\x1b[31mInvalid JSON in resume data\x1b[0m\n');
-      return;
+  for await (const event of stream) {
+    switch (event.type) {
+      case 'text':
+        process.stdout.write(event.content);
+        break;
+      case 'agent-label':
+        process.stdout.write(`\n\x1b[36m[${event.agentId}]\x1b[0m `);
+        break;
+      case 'usage':
+        recordUsage(sessionUsage, event.data);
+        process.stdout.write(`\x1b[90m[${formatUsage(event.data)}]\x1b[0m\n`);
+        break;
+      case 'error':
+        process.stdout.write(`\n\x1b[31mError: ${event.message}\x1b[0m\n`);
+        break;
+      case 'done':
+        break;
     }
-  }
-
-  const validWorkflows = ['patient-intake', 'diagnostic-research'] as const;
-  if (!validWorkflows.includes(workflowId as (typeof validWorkflows)[number])) {
-    process.stdout.write(`\x1b[31mUnknown workflow: ${workflowId}\x1b[0m\n`);
-    return;
-  }
-
-  // getWorkflow returns a union type; cast to access resume() which is available on all Workflow instances
-  const workflow = mastra.getWorkflow(workflowId as 'patient-intake') as unknown as {
-    resume: (params: { step: string; resumeData: unknown }) => Promise<unknown>;
-  };
-  process.stdout.write(`Resuming workflow "${workflowId}" at step "${stepId}"...\n`);
-
-  const result = await workflow.resume({
-    step: stepId,
-    resumeData,
-  });
-
-  process.stdout.write(`\nWorkflow result: ${JSON.stringify(result, null, 2)}\n`);
-}
-
-// ─── Direct Streaming Response ──────────────────────────────────────────────
-
-async function streamDirectResponse(userMessage: string, session: Session): Promise<void> {
-  const agent = mastra.getAgent(AGENT_ID);
-  const patientInstructions = getPatientInstructions(session);
-  const runId = `run-${Date.now()}`;
-
-  const result = await agent.stream(userMessage, {
-    runId,
-    maxSteps: resolveMaxSteps(userMessage),
-    memory: {
-      thread: session.threadId,
-      resource: session.resourceId,
-    },
-    ...(patientInstructions ? { instructions: patientInstructions } : {}),
-    onFinish: traceOnFinish(runId),
-    onStepFinish: traceOnStepFinish(runId),
-  });
-
-  const reader = result.textStream.getReader();
-
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      process.stdout.write(value);
-    }
-  } finally {
-    reader.releaseLock();
   }
 
   process.stdout.write('\n');
-
-  result.usage
-    .then((usage) => {
-      recordUsage(sessionUsage, usage);
-      process.stdout.write(`\x1b[90m[${formatUsage(usage)}]\x1b[0m\n`);
-    })
-    .catch(() => {
-      // Usage data unavailable — silently continue
-    });
 }
 
-// ─── Network Streaming Response ─────────────────────────────────────────────
-
-/** Process a single network stream chunk, printing agent labels and text deltas. */
-function processNetworkChunk(chunk: Record<string, unknown>, currentAgent: { id: string }): void {
-  const chunkType = chunk['type'] as string | undefined;
-  const payload = chunk['payload'] as Record<string, unknown> | undefined;
-
-  if (!(chunkType && payload)) return;
-
-  if (chunkType === 'agent-execution-start') {
-    const agentId = (payload['agentId'] as string) ?? 'unknown';
-    if (agentId !== currentAgent.id) {
-      currentAgent.id = agentId;
-      process.stdout.write(`\n\x1b[36m[${currentAgent.id}]\x1b[0m `);
-    }
-    return;
-  }
-
-  if (!chunkType.startsWith('agent-execution-event-')) return;
-
-  const innerType = (payload['type'] as string) ?? '';
-  if (innerType !== 'text-delta') return;
-
-  const innerPayload = payload['payload'] as Record<string, unknown> | undefined;
-  const text = (innerPayload?.['text'] as string) ?? '';
-  if (text) process.stdout.write(text);
-}
-
-async function streamNetworkResponse(userMessage: string, session: Session): Promise<void> {
-  const agent = mastra.getAgent(AGENT_ID);
-  const patientInstructions = getPatientInstructions(session);
-
-  process.stdout.write('\x1b[90m[network mode — routing to specialized agents]\x1b[0m\n');
-
-  const networkStream = await agent.network(userMessage, {
-    memory: {
-      thread: session.threadId,
-      resource: session.resourceId,
-    },
-    ...(patientInstructions ? { instructions: patientInstructions } : {}),
-    maxSteps: resolveMaxSteps(userMessage),
-  });
-
-  const reader = networkStream.getReader();
-  const currentAgent = { id: '' };
-
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      processNetworkChunk(value as Record<string, unknown>, currentAgent);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  process.stdout.write('\n');
-
-  networkStream.usage
-    .then((usage) => {
-      recordUsage(sessionUsage, usage);
-      process.stdout.write(`\x1b[90m[${formatUsage(usage)}]\x1b[0m\n`);
-    })
-    .catch(() => {
-      // Usage data unavailable — silently continue
-    });
-}
-
-// ─── Streaming Response (dispatches to direct or network) ───────────────────
-
-async function streamResponse(userMessage: string, session: Session): Promise<void> {
-  if (session.networkMode) {
-    await streamNetworkResponse(userMessage, session);
-  } else {
-    await streamDirectResponse(userMessage, session);
-  }
-}
-
-// ─── Slash Command Handling ──────────────────────────────────────────────────
+// ─── Slash Command Handling ─────────────────────────────────────────────────
 
 interface SlashCommandResult {
   session: Session;
@@ -207,7 +57,8 @@ async function handleSlashCommand(input: string, session: Session): Promise<Slas
 
   if (input.startsWith('/resume')) {
     try {
-      await handleResumeCommand(input);
+      const result = await handleResume(input);
+      process.stdout.write(`${result.output}\n`);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       process.stdout.write(`\x1b[31mResume error: ${message}\x1b[0m\n`);
@@ -222,7 +73,7 @@ async function handleSlashCommand(input: string, session: Session): Promise<Slas
 
 // ─── REPL Main Loop ─────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const { patientId } = parseArgs(process.argv.slice(2));
 
   let session = createSession(patientId ? `patient-${patientId}` : undefined);
@@ -265,7 +116,7 @@ async function main(): Promise<void> {
     }
 
     try {
-      await streamResponse(input, session);
+      await writeStreamToStdout(input, session);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error('Agent error', { error: message });
@@ -303,7 +154,6 @@ async function main(): Promise<void> {
 
   rl.on('close', () => {
     if (processing) {
-      // Wait for pending operations before exiting
       const check = setInterval(() => {
         if (!processing) {
           clearInterval(check);
@@ -316,9 +166,14 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  logger.error('Fatal error', { error: message });
-  process.stderr.write(`Fatal: ${message}\n`);
-  process.exit(1);
-});
+// Auto-run when executed directly (not imported as a module by tui.tsx)
+const isDirectRun = process.argv[1]?.endsWith('/cli.js') || process.argv[1]?.endsWith('/cli.ts');
+
+if (isDirectRun) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Fatal error', { error: message });
+    process.stderr.write(`Fatal: ${message}\n`);
+    process.exit(1);
+  });
+}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+import { parseArgs } from './cli-utils.js';
+import { logger } from './utils/logger.js';
+
+const { patientId } = parseArgs(process.argv.slice(2));
+
+// Ink requires raw mode on stdin — only available in real TTY terminals.
+// Fall back to the readline REPL when running in CI, piped input, or non-TTY.
+if (!process.stdin.isTTY) {
+  logger.warn('TUI requires an interactive terminal — falling back to REPL mode');
+  const { main } = await import('./cli.js');
+  await main();
+} else {
+  const { render } = await import('ink');
+  const { App } = await import('./tui/App.js');
+  render(<App {...(patientId ? { patientId } : {})} />);
+}

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render } from 'ink-testing-library';
+import { App } from './App.js';
+
+// Mock the heavy dependencies so the component renders without real agent calls
+jest.mock('../mastra.js', () => ({
+  mastra: {
+    getAgent: jest.fn(),
+    getWorkflow: jest.fn(),
+  },
+}));
+
+jest.mock('../memory.js', () => ({
+  storage: {},
+  memory: {},
+  brainMemory: {},
+}));
+
+describe('App', () => {
+  it('renders Asklepios header', () => {
+    const { lastFrame } = render(<App />);
+    const frame = lastFrame();
+    expect(frame).toContain('Asklepios');
+  });
+
+  it('shows DIRECT mode by default', () => {
+    const { lastFrame } = render(<App />);
+    expect(lastFrame()).toContain('[DIRECT]');
+  });
+
+  it('shows help hint when no messages', () => {
+    const { lastFrame } = render(<App />);
+    expect(lastFrame()).toContain('Type a message');
+    expect(lastFrame()).toContain('/help');
+  });
+
+  it('shows patient label when patientId provided', () => {
+    const { lastFrame } = render(<App patientId="maria-kowalski" />);
+    expect(lastFrame()).toContain('maria-kowalski');
+  });
+
+  it('shows asklepios label when no patient', () => {
+    const { lastFrame } = render(<App />);
+    expect(lastFrame()).toContain('asklepios');
+  });
+
+  it('renders input bar with prompt', () => {
+    const { lastFrame } = render(<App />);
+    const frame = lastFrame();
+    // Input bar should show the prompt
+    expect(frame).toContain('>');
+  });
+
+  it('renders complete layout with all sections', () => {
+    const { lastFrame } = render(<App patientId="maria-kowalski" />);
+    const frame = lastFrame() ?? '';
+
+    // Header
+    expect(frame).toContain('Asklepios');
+    expect(frame).toContain('maria-kowalski');
+    expect(frame).toContain('[DIRECT]');
+
+    // Help hint (no messages yet)
+    expect(frame).toContain('Type a message');
+
+    // Input bar
+    expect(frame).toContain('>');
+  });
+});

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,0 +1,79 @@
+import type { Key } from 'ink';
+import { Box, useApp, useInput, useStdout } from 'ink';
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { ConversationPane } from './ConversationPane.js';
+import { Header } from './Header.js';
+import { InputBar } from './InputBar.js';
+import { BG_DEEP } from './theme.js';
+import { useAsklepios } from './useAsklepios.js';
+
+interface AppProps {
+  patientId?: string | undefined;
+}
+
+export function App({ patientId }: AppProps): React.JSX.Element {
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+  const [rows, setRows] = useState(stdout.rows ?? 24);
+
+  // Track terminal resize
+  useEffect(() => {
+    const onResize = (): void => {
+      setRows(stdout.rows ?? 24);
+    };
+    stdout.on('resize', onResize);
+    return () => {
+      stdout.off('resize', onResize);
+    };
+  }, [stdout]);
+
+  const {
+    messages,
+    isStreaming,
+    session,
+    sessionUsage,
+    streamingText,
+    streamingAgentId,
+    sendMessage,
+    handleSlashCommand,
+  } = useAsklepios(patientId ? { initialPatientId: patientId } : {});
+
+  // Keyboard shortcuts
+  useInput((_input: string, key: Key) => {
+    if (key.ctrl && _input === 'n') {
+      handleSlashCommand('/new');
+    }
+    if (key.ctrl && _input === 't') {
+      handleSlashCommand('/network');
+    }
+  });
+
+  const handleQuit = (): void => {
+    exit();
+  };
+
+  return (
+    <Box flexDirection="column" height={rows} backgroundColor={BG_DEEP}>
+      {/* Header — fixed at top */}
+      <Header session={session} sessionUsage={sessionUsage} />
+
+      {/* Conversation — fills remaining space, overflow hidden */}
+      <ConversationPane
+        messages={messages}
+        isStreaming={isStreaming}
+        streamingText={streamingText}
+        streamingAgentId={streamingAgentId}
+      />
+
+      {/* Input bar — fixed at bottom */}
+      <InputBar
+        session={session}
+        isStreaming={isStreaming}
+        onSubmit={sendMessage}
+        onCommand={handleSlashCommand}
+        onQuit={handleQuit}
+      />
+    </Box>
+  );
+}

--- a/src/tui/ConversationPane.tsx
+++ b/src/tui/ConversationPane.tsx
@@ -1,0 +1,66 @@
+import { Spinner } from '@inkjs/ui';
+import { Box, Text } from 'ink';
+import type React from 'react';
+import { MessageBubble } from './MessageBubble.js';
+import { ACCENT, DANGER, FG, SURFACE_500 } from './theme.js';
+import type { Message } from './types.js';
+
+interface ConversationPaneProps {
+  messages: Message[];
+  isStreaming: boolean;
+  streamingText: string;
+  streamingAgentId: string;
+}
+
+export function ConversationPane({
+  messages,
+  isStreaming,
+  streamingText,
+  streamingAgentId,
+}: ConversationPaneProps): React.JSX.Element {
+  const hasContent = messages.length > 0 || isStreaming;
+
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      overflowY="hidden"
+      justifyContent={hasContent ? 'flex-end' : 'center'}
+    >
+      {/* Empty state */}
+      {!hasContent ? (
+        <Box justifyContent="center" alignItems="center">
+          <Text color={SURFACE_500}>
+            Type a message to start. <Text color={ACCENT}>/help</Text> for commands. Ctrl+N new
+            thread, Ctrl+T toggle network.
+          </Text>
+        </Box>
+      ) : null}
+
+      {/* Completed messages — gravity to bottom so newest are always visible */}
+      {messages.map((message: Message) => (
+        <Box key={message.id}>
+          <MessageBubble message={message} />
+        </Box>
+      ))}
+
+      {/* Currently streaming message */}
+      {isStreaming ? (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color={DANGER} bold>
+            Asklepios{streamingAgentId ? ` [${streamingAgentId}]` : ''}:
+          </Text>
+          <Box marginLeft={2}>
+            {streamingText ? (
+              <Text color={FG} wrap="wrap">
+                {streamingText}
+              </Text>
+            ) : (
+              <Spinner label="Thinking..." />
+            )}
+          </Box>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/tui/Header.test.tsx
+++ b/src/tui/Header.test.tsx
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import { render } from 'ink-testing-library';
+import { createSessionUsage } from '../utils/usage-tracker.js';
+import { Header } from './Header.js';
+
+jest.mock('../mastra.js', () => ({
+  mastra: {
+    getAgent: jest.fn(),
+    getWorkflow: jest.fn(),
+  },
+}));
+
+jest.mock('../memory.js', () => ({
+  storage: {},
+  memory: {},
+  brainMemory: {},
+}));
+
+describe('Header', () => {
+  const baseSession = {
+    resourceId: 'patient-maria-kowalski',
+    threadId: 'aaaabbbb-cccc-dddd-eeee-ffffffffffff',
+    networkMode: false,
+  };
+
+  it('renders patient name from resourceId', () => {
+    const { lastFrame } = render(
+      <Header session={baseSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('maria-kowalski');
+  });
+
+  it('renders truncated thread ID', () => {
+    const { lastFrame } = render(
+      <Header session={baseSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('aaaabbbb');
+  });
+
+  it('shows DIRECT mode by default', () => {
+    const { lastFrame } = render(
+      <Header session={baseSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[DIRECT]');
+  });
+
+  it('shows NET mode when networkMode is true', () => {
+    const netSession = { ...baseSession, networkMode: true };
+    const { lastFrame } = render(
+      <Header session={netSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[NET]');
+  });
+
+  it('shows asklepios when no patient context', () => {
+    const defaultSession = {
+      ...baseSession,
+      resourceId: 'asklepios-knowledge',
+    };
+    const { lastFrame } = render(
+      <Header session={defaultSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('asklepios');
+  });
+
+  it('shows token usage from sessionUsage', () => {
+    const usage = createSessionUsage();
+    usage.totals.inputTokens = 1234;
+    usage.totals.outputTokens = 567;
+    const { lastFrame } = render(<Header session={baseSession} sessionUsage={usage} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('1,234');
+    expect(frame).toContain('567');
+  });
+
+  it('renders Asklepios title', () => {
+    const { lastFrame } = render(
+      <Header session={baseSession} sessionUsage={createSessionUsage()} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Asklepios');
+  });
+});

--- a/src/tui/Header.tsx
+++ b/src/tui/Header.tsx
@@ -1,0 +1,46 @@
+import { Box, Text } from 'ink';
+import type React from 'react';
+import type { Session } from '../cli-utils.js';
+import { DEFAULT_RESOURCE } from '../cli-utils.js';
+import type { SessionUsage } from '../utils/usage-tracker.js';
+import { ACCENT, ACCENT_DARK, BG_MID, SUCCESS, SURFACE_400, WARNING } from './theme.js';
+
+interface HeaderProps {
+  session: Session;
+  sessionUsage: SessionUsage;
+}
+
+export function Header({ session, sessionUsage }: HeaderProps): React.JSX.Element {
+  const label =
+    session.resourceId === DEFAULT_RESOURCE
+      ? 'asklepios'
+      : session.resourceId.replace(/^patient-/, '');
+
+  const threadShort = session.threadId.slice(0, 8);
+  const mode = session.networkMode ? 'NET' : 'DIRECT';
+  const { totals } = sessionUsage;
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={ACCENT_DARK}
+      paddingX={1}
+      justifyContent="space-between"
+      backgroundColor={BG_MID}
+    >
+      <Text bold color={ACCENT}>
+        Asklepios
+      </Text>
+      <Text color={SURFACE_400}>
+        patient: <Text color={SUCCESS}>{label}</Text>
+      </Text>
+      <Text color={SURFACE_400}>
+        thread: <Text color={SURFACE_400}>{threadShort}</Text>
+      </Text>
+      <Text color={session.networkMode ? WARNING : SUCCESS}>[{mode}]</Text>
+      <Text color={SURFACE_400}>
+        {totals.inputTokens.toLocaleString()} in / {totals.outputTokens.toLocaleString()} out
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/InputBar.tsx
+++ b/src/tui/InputBar.tsx
@@ -1,0 +1,83 @@
+import { TextInput } from '@inkjs/ui';
+import { Box, Text } from 'ink';
+import type React from 'react';
+import { useState } from 'react';
+import type { Session } from '../cli-utils.js';
+import { DEFAULT_RESOURCE } from '../cli-utils.js';
+import { ACCENT, ACCENT_DARK, BG_MID, SURFACE_400, SURFACE_500, WARNING } from './theme.js';
+
+interface InputBarProps {
+  session: Session;
+  isStreaming: boolean;
+  onSubmit: (text: string) => void;
+  onCommand: (input: string) => string | undefined;
+  onQuit: () => void;
+}
+
+const SLASH_COMMANDS = [
+  '/help',
+  '/patient',
+  '/thread',
+  '/new',
+  '/status',
+  '/usage',
+  '/network',
+  '/resume',
+  '/quit',
+];
+
+export function InputBar({
+  session,
+  isStreaming,
+  onSubmit,
+  onCommand,
+  onQuit,
+}: InputBarProps): React.JSX.Element {
+  // Increment key to force TextInput remount (clears internal state)
+  const [inputKey, setInputKey] = useState(0);
+
+  const label =
+    session.resourceId === DEFAULT_RESOURCE
+      ? 'asklepios'
+      : session.resourceId.replace(/^patient-/, '');
+
+  const modeIndicator = session.networkMode ? ' [net]' : '';
+  const prompt = `${label}${modeIndicator}`;
+
+  const handleSubmit = (value: string): void => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    // Force remount to clear TextInput internal state
+    setInputKey((k) => k + 1);
+
+    if (trimmed.startsWith('/')) {
+      const result = onCommand(trimmed);
+      if (result === 'quit') {
+        onQuit();
+      }
+      return;
+    }
+
+    onSubmit(trimmed);
+  };
+
+  return (
+    <Box borderStyle="single" borderColor={ACCENT_DARK} paddingX={1} backgroundColor={BG_MID}>
+      <Text color={ACCENT} bold>
+        {prompt}
+      </Text>
+      <Text color={session.networkMode ? WARNING : SURFACE_400}> {'> '}</Text>
+      {isStreaming ? (
+        <Text color={SURFACE_500}>Thinking...</Text>
+      ) : (
+        <TextInput
+          key={inputKey}
+          placeholder="Type a message or /help for commands..."
+          suggestions={SLASH_COMMANDS}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/tui/MessageBubble.test.tsx
+++ b/src/tui/MessageBubble.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@jest/globals';
+import { render } from 'ink-testing-library';
+import { MessageBubble } from './MessageBubble.js';
+import type { Message } from './types.js';
+
+describe('MessageBubble', () => {
+  it('renders user message with You label', () => {
+    const msg: Message = { id: 1, role: 'user', content: 'What is vEDS?' };
+    const { lastFrame } = render(<MessageBubble message={msg} />);
+    const frame = lastFrame();
+    expect(frame).toContain('You:');
+    expect(frame).toContain('What is vEDS?');
+  });
+
+  it('renders assistant message with Asklepios label', () => {
+    const msg: Message = {
+      id: 2,
+      role: 'assistant',
+      content: 'vEDS is a connective tissue disorder.',
+    };
+    const { lastFrame } = render(<MessageBubble message={msg} />);
+    const frame = lastFrame();
+    expect(frame).toContain('Asklepios');
+    expect(frame).toContain('vEDS is a connective tissue disorder.');
+  });
+
+  it('renders system message as dim text', () => {
+    const msg: Message = { id: 3, role: 'system', content: 'Patient set to maria-kowalski' };
+    const { lastFrame } = render(<MessageBubble message={msg} />);
+    expect(lastFrame()).toContain('Patient set to maria-kowalski');
+  });
+
+  it('shows agent label for network mode messages', () => {
+    const msg: Message = {
+      id: 4,
+      role: 'assistant',
+      content: 'Research results',
+      agentId: 'research-agent',
+    };
+    const { lastFrame } = render(<MessageBubble message={msg} />);
+    expect(lastFrame()).toContain('[research-agent]');
+  });
+
+  it('shows token usage when available', () => {
+    const msg: Message = {
+      id: 5,
+      role: 'assistant',
+      content: 'Analysis complete.',
+      tokens: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
+    };
+    const { lastFrame } = render(<MessageBubble message={msg} />);
+    const frame = lastFrame();
+    expect(frame).toContain('1,000');
+    expect(frame).toContain('500');
+  });
+});

--- a/src/tui/MessageBubble.tsx
+++ b/src/tui/MessageBubble.tsx
@@ -1,0 +1,56 @@
+import { Box, Text } from 'ink';
+import type React from 'react';
+import { formatUsage } from '../utils/usage-tracker.js';
+import { ACCENT, ACCENT_DARK, DANGER, FG, SURFACE_400 } from './theme.js';
+import type { Message } from './types.js';
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+export function MessageBubble({ message }: MessageBubbleProps): React.JSX.Element {
+  if (message.role === 'user') {
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color={ACCENT} bold>
+          You:
+        </Text>
+        <Box marginLeft={2}>
+          <Text>{message.content}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (message.role === 'system') {
+    return (
+      <Box marginBottom={1} flexDirection="column">
+        <Text color={ACCENT_DARK}>{'─── system ───'}</Text>
+        <Box marginLeft={2}>
+          <Text color={FG}>{message.content}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Assistant message
+  const agentLabel = message.agentId ? ` [${message.agentId}]` : '';
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color={DANGER} bold>
+        Asklepios{agentLabel}:
+      </Text>
+      <Box marginLeft={2} flexDirection="column">
+        <Text color={FG} wrap="wrap">
+          {message.content}
+        </Text>
+        {message.tokens ? (
+          <Text color={SURFACE_400} italic>
+            [{formatUsage(message.tokens)}]
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,0 +1,30 @@
+/**
+ * Asklepios brand colors for TUI components.
+ * Terminal hex colors — Ink/chalk support hex strings directly.
+ */
+
+// Background (Midnight)
+export const BG_DEEP = '#030712';
+export const BG_MID = '#0a0f1e';
+export const BG_BASE = '#0f172a';
+export const FG = '#f8fafc';
+
+// Aurora Teal (Primary Accent)
+export const ACCENT = '#00f5d4';
+export const ACCENT_LIGHT = '#67f5e0';
+export const ACCENT_DARK = '#00c4a7';
+export const SUCCESS = '#2dd4bf';
+
+// Neon Pink (Aurora Pink)
+export const DANGER = '#e879f9';
+
+// Surface Scale (Slate Grays)
+export const SURFACE_300 = '#cbd5e1';
+export const SURFACE_400 = '#94a3b8';
+export const SURFACE_500 = '#64748b';
+export const SURFACE_600 = '#475569';
+export const SURFACE_700 = '#334155';
+export const SURFACE_800 = '#1e293b';
+
+// Other
+export const WARNING = '#fbbf24';

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -1,0 +1,9 @@
+import type { TokenUsage } from '../utils/usage-tracker.js';
+
+export interface Message {
+  id: number;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  tokens?: TokenUsage | undefined;
+  agentId?: string | undefined;
+}

--- a/src/tui/useAsklepios.ts
+++ b/src/tui/useAsklepios.ts
@@ -1,0 +1,174 @@
+/**
+ * Core hook encapsulating all agent interaction logic for the TUI.
+ * Manages messages, streaming state, session, and slash commands.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { StreamEvent } from '../cli-core.js';
+import { handleResume, streamAgent } from '../cli-core.js';
+import type { Session } from '../cli-utils.js';
+import { createSession, handleCommand } from '../cli-utils.js';
+import type { SessionUsage } from '../utils/usage-tracker.js';
+import { createSessionUsage, formatSessionUsage, recordUsage } from '../utils/usage-tracker.js';
+import type { Message } from './types.js';
+
+export interface UseAsklepiosOptions {
+  initialPatientId?: string | undefined;
+}
+
+export interface UseAsklepiosReturn {
+  messages: Message[];
+  isStreaming: boolean;
+  session: Session;
+  sessionUsage: SessionUsage;
+  streamingText: string;
+  streamingAgentId: string;
+  sendMessage: (text: string) => void;
+  handleSlashCommand: (input: string) => string | undefined;
+}
+
+let nextMsgId = 0;
+
+function nextId(): number {
+  return ++nextMsgId;
+}
+
+function sysMsg(content: string): Message {
+  return { id: nextId(), role: 'system', content };
+}
+
+function buildAssistantMsg(content: string, agent: string, tokens?: Message['tokens']): Message {
+  const msg: Message = { id: nextId(), role: 'assistant', content };
+  if (agent) msg.agentId = agent;
+  if (tokens) msg.tokens = tokens;
+  return msg;
+}
+
+export function useAsklepios(options: UseAsklepiosOptions = {}): UseAsklepiosReturn {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [session, setSession] = useState<Session>(() =>
+    createSession(options.initialPatientId ? `patient-${options.initialPatientId}` : undefined),
+  );
+  const [usage] = useState<SessionUsage>(() => createSessionUsage());
+  const [streamingText, setStreamingText] = useState('');
+  const [streamingAgentId, setStreamingAgentId] = useState('');
+  // Force re-render when usage updates since SessionUsage is mutated in place
+  const [, setUsageTick] = useState(0);
+
+  const streamingRef = useRef(false);
+
+  const handleStreamEvent = useCallback(
+    (
+      event: StreamEvent,
+      acc: { text: string; agentId: string },
+    ): { text: string; agentId: string } => {
+      if (event.type === 'text') {
+        const text = acc.text + event.content;
+        setStreamingText(text);
+        return { ...acc, text };
+      }
+      if (event.type === 'agent-label') {
+        setStreamingAgentId(event.agentId);
+        return { ...acc, agentId: event.agentId };
+      }
+      if (event.type === 'usage') {
+        recordUsage(usage, event.data);
+        setUsageTick((n) => n + 1);
+        setMessages((prev) => [...prev, buildAssistantMsg(acc.text, acc.agentId, event.data)]);
+        return { ...acc, text: '' };
+      }
+      if (event.type === 'done' && acc.text) {
+        setMessages((prev) => [...prev, buildAssistantMsg(acc.text, acc.agentId)]);
+      }
+      if (event.type === 'error') {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: 'system', content: `Error: ${event.message}` },
+        ]);
+      }
+      return acc;
+    },
+    [usage],
+  );
+
+  const processStream = useCallback(
+    async (stream: AsyncGenerator<StreamEvent>) => {
+      let acc = { text: '', agentId: '' };
+      for await (const event of stream) {
+        acc = handleStreamEvent(event, acc);
+      }
+    },
+    [handleStreamEvent],
+  );
+
+  const sendMessage = useCallback(
+    (text: string) => {
+      if (streamingRef.current) return;
+      streamingRef.current = true;
+      setIsStreaming(true);
+      setStreamingText('');
+      setStreamingAgentId('');
+
+      setMessages((prev) => [...prev, { id: nextId(), role: 'user', content: text }]);
+
+      const stream = streamAgent(text, session);
+
+      processStream(stream)
+        .catch((error: unknown) => {
+          const msg = error instanceof Error ? error.message : String(error);
+          setMessages((prev) => [...prev, sysMsg(`Error: ${msg}`)]);
+        })
+        .finally(() => {
+          streamingRef.current = false;
+          setIsStreaming(false);
+          setStreamingText('');
+          setStreamingAgentId('');
+        });
+    },
+    [session, processStream],
+  );
+
+  const handleSlashCommand = useCallback(
+    (input: string): string | undefined => {
+      if (input === '/usage') {
+        const output = formatSessionUsage(usage);
+        setMessages((prev) => [...prev, sysMsg(output)]);
+        return undefined;
+      }
+
+      if (input.startsWith('/resume')) {
+        handleResume(input)
+          .then((result) => {
+            setMessages((prev) => [...prev, sysMsg(result.output)]);
+          })
+          .catch((error: unknown) => {
+            const msg = error instanceof Error ? error.message : String(error);
+            setMessages((prev) => [...prev, sysMsg(`Resume error: ${msg}`)]);
+          });
+        return undefined;
+      }
+
+      const result = handleCommand(input, session);
+      if (result.quit) return 'quit';
+
+      setSession(result.session);
+      if (result.output) {
+        setMessages((prev) => [...prev, sysMsg(result.output)]);
+      }
+      return undefined;
+    },
+    [session, usage],
+  );
+
+  return {
+    messages,
+    isStreaming,
+    session,
+    sessionUsage: usage,
+    streamingText,
+    streamingAgentId,
+    sendMessage,
+    handleSlashCommand,
+  };
+}

--- a/src/utils/anthropic-provider.ts
+++ b/src/utils/anthropic-provider.ts
@@ -2,6 +2,13 @@ import { execSync } from 'node:child_process';
 import type { AnthropicProvider } from '@ai-sdk/anthropic';
 import { createAnthropic } from '@ai-sdk/anthropic';
 
+/** Strip leading ASCII control characters (0x00–0x1F) from hex-decoded keychain blobs. */
+function stripLeadingControlChars(s: string): string {
+  let i = 0;
+  while (i < s.length && s.charCodeAt(i) < 0x20) i++;
+  return s.slice(i);
+}
+
 import { logger } from './logger.js';
 
 interface ClaudeCodeCredentials {
@@ -28,30 +35,39 @@ function readClaudeCodeToken(): string | undefined {
   }
 
   try {
-    const hex = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+    const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
       encoding: 'utf-8',
       timeout: 5_000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
 
-    const decoded = Buffer.from(hex, 'hex').toString('utf-8');
-    const jsonStart = decoded.indexOf('{');
-    if (jsonStart === -1) {
-      logger.debug('No JSON found in Claude Code keychain entry');
-      return undefined;
-    }
+    // Keychain entry may be raw JSON or hex-encoded — try both
+    const text = raw.startsWith('{')
+      ? raw
+      : stripLeadingControlChars(Buffer.from(raw, 'hex').toString('utf-8'));
 
-    const creds: ClaudeCodeCredentials = JSON.parse(decoded.slice(jsonStart));
-    const token = creds.claudeAiOauth?.accessToken;
+    // Try full JSON parse first; fall back to regex for truncated blobs
+    let token: string | undefined;
+    let expiresAt: number | undefined;
+    try {
+      const jsonStr = text.startsWith('{') ? text : `{${text}}`;
+      const creds: ClaudeCodeCredentials = JSON.parse(jsonStr);
+      token = creds.claudeAiOauth?.accessToken;
+      expiresAt = creds.claudeAiOauth?.expiresAt;
+    } catch {
+      // Hex blob may be truncated — extract token via regex
+      const tokenMatch = text.match(/"accessToken":"([^"]+)"/);
+      const expiryMatch = text.match(/"expiresAt":(\d+)/);
+      token = tokenMatch?.[1];
+      expiresAt = expiryMatch?.[1] ? Number(expiryMatch[1]) : undefined;
+    }
 
     if (!token) {
       logger.debug('No OAuth access token in Claude Code credentials');
       return undefined;
     }
 
-    const now = Date.now();
-    const expiresAt = creds.claudeAiOauth?.expiresAt;
-    if (expiresAt && expiresAt < now) {
+    if (expiresAt && expiresAt < Date.now()) {
       logger.warn('Claude Code OAuth token has expired — run `claude` to refresh');
       return undefined;
     }
@@ -67,26 +83,6 @@ function readClaudeCodeToken(): string | undefined {
 export type AuthMethod = 'env' | 'claude-code';
 
 /**
- * Resolves the Anthropic API key by auth method.
- *
- * - `'env'` (default): uses the `ANTHROPIC_API_KEY` environment variable.
- *   When running inside a Claude Code session, this env var is already set.
- * - `'claude-code'`: reads the OAuth access token directly from the macOS Keychain
- *   (useful when launching outside a Claude Code session but still using your
- *   Claude Code subscription).
- *
- * Falls back to `'env'` if `'claude-code'` fails to read credentials.
- */
-function resolveApiKey(method: AuthMethod): string | undefined {
-  if (method === 'claude-code') {
-    const token = readClaudeCodeToken();
-    if (token) return token;
-    logger.warn('Claude Code auth failed, falling back to ANTHROPIC_API_KEY env var');
-  }
-  return process.env['ANTHROPIC_API_KEY'];
-}
-
-/**
  * Creates a configured Anthropic provider.
  *
  * @param authMethod - How to authenticate:
@@ -99,8 +95,16 @@ export function getAnthropicProvider(authMethod?: AuthMethod): AnthropicProvider
   const method: AuthMethod =
     authMethod ?? (process.env['ASKLEPIOS_AUTH'] as AuthMethod | undefined) ?? 'env';
 
-  const apiKey = resolveApiKey(method);
+  if (method === 'claude-code') {
+    const token = readClaudeCodeToken();
+    if (token) {
+      // Claude Code OAuth tokens work as x-api-key (not Bearer)
+      return createAnthropic({ apiKey: token });
+    }
+    logger.warn('Claude Code auth failed, falling back to ANTHROPIC_API_KEY env var');
+  }
 
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
   return createAnthropic({
     ...(apiKey ? { apiKey } : {}),
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "jsx": "react-jsx",
 
     /* Strict Type Checking — ALL enabled, no exceptions */
     "strict": true,
@@ -34,6 +35,6 @@
     "allowImportingTsExtensions": false,
     "esModuleInterop": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,5 +6,5 @@
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "src/**/*.test.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.test.ts", "src/**/*.test.tsx", "test/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Adds an Ink-powered React terminal UI (closes #20) with a split-pane layout: fixed header at top, scrollable conversation pane in the middle, and input bar at the bottom.

### New files (14)
- **`src/cli-core.ts`** — Event-based streaming interface (`AsyncGenerator<StreamEvent>`) shared by both REPL and TUI
- **`src/tui.tsx`** — TUI entry point with TTY guard (falls back to REPL for non-interactive stdin)
- **`src/tui/App.tsx`** — Root component: fullscreen layout with terminal resize tracking
- **`src/tui/Header.tsx`** — Patient context, thread ID, network mode, token counters
- **`src/tui/ConversationPane.tsx`** — Message list with `justifyContent: flex-end` auto-scroll
- **`src/tui/MessageBubble.tsx`** — Role-based styling (user/assistant/system)
- **`src/tui/InputBar.tsx`** — TextInput with key-based remount, slash command dispatch
- **`src/tui/useAsklepios.ts`** — React hook encapsulating all agent interaction state
- **`src/tui/theme.ts`** — Brand palette (Midnight, Aurora Teal, Neon Pink)
- **`src/tui/types.ts`** — Message interface
- Tests: `App.test.tsx`, `Header.test.tsx`, `MessageBubble.test.tsx`, `cli-core.test.ts`

### Modified files
- **`src/cli.ts`** — Refactored to consume `cli-core.ts` generators (325→175 lines)
- **`src/utils/anthropic-provider.ts`** — Fixed keychain parser (regex fallback for truncated hex blobs), `apiKey` for OAuth tokens
- **`package.json`** — Added ink, react, @inkjs/ui; `--env-file=.env` in scripts
- Config: `tsconfig.json`, `biome.json`, `jest.config.js` updated for JSX

### Test plan
- `npm run check` passes (342 tests / 33 suites, 0 type errors, 0 lint errors)
- Manual testing in tmux: streaming, slash commands (/help /status /usage /network /quit), token tracking, multi-turn conversation, network mode toggle all verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new runtime entrypoint/dependencies (Ink + React 19) and refactoring of CLI streaming/resume paths, plus changes to authentication token parsing logic.
> 
> **Overview**
> Introduces an Ink/React **split-pane TUI** (new default `npm start`) with header, scrollable conversation area, and input bar supporting slash-command suggestions plus keyboard shortcuts, with an automatic fallback to the readline REPL when not running in a TTY.
> 
> Refactors the existing REPL to consume a new `cli-core.ts` layer that streams agent output via `AsyncGenerator<StreamEvent>` for both direct and network modes, and centralizes `/resume` workflow handling.
> 
> Updates build/test/lint plumbing for `.tsx` (Biome, TS `jsx`, Jest ESM config/coverage), adds Ink/React dependencies and a new `asklepios-tui` bin, and hardens Claude Code keychain auth parsing in `anthropic-provider.ts` (handles raw JSON vs hex blobs and truncated data).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94210616a2f4947813d34ceac759f8274afc8e27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->