### PR TITLE
fix: resolve pre-existing test failures (34 tests fixed)

### DIFF
--- a/src/agents/asklepios.test.ts
+++ b/src/agents/asklepios.test.ts
@@ -22,7 +22,7 @@ describe('asklepiosAgent', () => {
 
   it('has instructions about three-layer architecture', async () => {
     const instructions = await asklepiosAgent.getInstructions();
-    expect(instructions).toContain('Three-Layer Clinical Knowledge Architecture');
+    expect(instructions).toContain('Six-Layer Inverted Pyramid Architecture');
   });
 
   it('has all required tools configured', () => {

--- a/src/tools/capture-data.test.ts
+++ b/src/tools/capture-data.test.ts
@@ -1,37 +1,30 @@
-import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
-import { ClinicalStore } from '../storage/clinical-store.js';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ClinicalStore, setClinicalStoreForTest } from '../storage/clinical-store.js';
+import { captureDataTool as _captureDataTool } from './capture-data.js';
+
+// biome-ignore lint/suspicious/noExplicitAny: tool.execute signature requires context arg we skip in tests
+const captureDataTool = _captureDataTool as any;
 
 const TEST_PATIENT = 'patient-capture-test';
 
 /**
  * Tests for the consolidated captureData tool.
- * Verifies discriminated-union routing for all 6 capture types.
+ * Verifies discriminated-union routing for all capture types.
  *
  * Uses an in-memory SQLite database for isolation.
- *
- * Strategy: import the real ClinicalStore class directly, create an
- * in-memory store, then use jest.unstable_mockModule to intercept
- * getClinicalStore() so the tool writes to our in-memory store.
- * The tool module is dynamically imported AFTER the mock is registered.
+ * Uses setClinicalStoreForTest to inject the in-memory store
+ * into the singleton used by the tool.
  */
 
 const memStore = new ClinicalStore('file::memory:?cache=shared');
 
-jest.unstable_mockModule('../storage/clinical-store.js', () => ({
-  ClinicalStore,
-  getClinicalStore: () => memStore,
-}));
-
-// biome-ignore lint/suspicious/noExplicitAny: dynamically imported in beforeAll
-let captureDataTool: any;
-
 beforeAll(async () => {
-  const mod = await import('./capture-data.js');
-  captureDataTool = mod.captureDataTool;
   await memStore.ensureInitialized();
+  setClinicalStoreForTest(memStore);
 });
 
 afterAll(async () => {
+  setClinicalStoreForTest(undefined as unknown as ClinicalStore);
   await memStore.close();
 });
 
@@ -210,6 +203,7 @@ describe('captureDataTool', () => {
         value: 2.59,
         unit: 'tys/µl',
         date: '2025-01-10',
+        source: 'ALAB',
       });
 
       expect(result.success).toBe(true);
@@ -250,6 +244,7 @@ describe('captureDataTool', () => {
         value: 'positive (329.41 U/ml)',
         unit: 'qualitative',
         date: '2025-02-01',
+        source: 'Diagnostyka',
       });
 
       expect(result.success).toBe(true);
@@ -400,6 +395,7 @@ describe('captureDataTool', () => {
           value: 1,
           unit: 'u',
           date: '2025-01-01',
+          source: 'Lab X',
           prefix: 'lab-',
         },
         {


### PR DESCRIPTION
## Summary

Fixes 34 pre-existing test failures across 3 test files that were broken before the data layer redesign.

### Root Causes Fixed

1. **ESM mock broken** (capture-data.test.ts, query-data.test.ts)
   - `jest.unstable_mockModule` was not intercepting `getClinicalStore()` due to static import order
   - Fix: use `setClinicalStoreForTest()` to directly inject in-memory store singleton

2. **Lab results missing `source` field** (capture-data.test.ts, query-data.test.ts)
   - `requireLabSource` validation added but test fixtures not updated
   - Fix: add `source` field to all lab test fixtures

3. **Instruction text assertion outdated** (asklepios.test.ts)
   - Architecture name changed from 'Three-Layer' to 'Six-Layer Inverted Pyramid'
   - Fix: update assertion

4. **EvidenceTier enum mismatch** (query-data.test.ts)
   - Hypothesis schema uses short `T1/T2/T3` but test used long form
   - Fix: use short-form values

### Results

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Tests passed | 889 | 1053 | **+164** |
| Tests failed | 60 | 26 | **-34** |
| Suites passed | 53 | 70 | **+17** |
| Suites failed | 23 | 6 | **-17** |

Remaining 6 failing suites are pre-existing `@mastra/mcp` ESM compatibility issues.

### Test Plan
- `npx jest src/tools/query-data.test.ts` — 28/28 pass
- `npx jest src/tools/capture-data.test.ts` — 20/20 pass  
- `npx jest src/mcp/server.test.ts` — 69/69 pass
- `npx tsc --noEmit` — 0 errors
- `npx biome check` — 0 errors on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust mocks and fixtures to align with updated schemas; no production logic changes.
> 
> **Overview**
> Fixes pre-existing Jest failures by updating tests to match recent data-layer changes.
> 
> `capture-data.test.ts` now injects an in-memory `ClinicalStore` via `setClinicalStoreForTest()` (instead of flaky ESM `jest.unstable_mockModule` mocking) and updates lab-result fixtures to include the newly-required `source` field. `asklepios.test.ts` updates the instructions assertion to the renamed architecture string (“Six-Layer Inverted Pyramid Architecture”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f639d78ffb0da56fb48ae68603fcf3be29bbb335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->